### PR TITLE
Feat add map store

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,5 @@
+* 2.10.0
+   - Add map as avro store, and use it as default.
 * 2.9.10
    - Optimize avro:is_same_type/2
    - Upgrade jsone to 1.8.1

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,6 @@
 * 2.10.0
    - Add map as avro store, and use it as default.
+   - Changed to store type aliases as type's full name index, so the type store map (or dict) is less bloated.
 * 2.9.10
    - Optimize avro:is_same_type/2
    - Upgrade jsone to 1.8.1

--- a/src/avro_util.erl
+++ b/src/avro_util.erl
@@ -83,10 +83,10 @@ ensure_lkup_fun(Sc) ->
     false -> make_lkup_fun(?ASSIGNED_NAME, Sc)
   end.
 
-%% @doc Make a schema store (dict based) and wrap it in a lookup fun.
+%% @doc Make a schema store (map based) and wrap it in a lookup fun.
 -spec make_lkup_fun(name_raw(), avro_type()) -> lkup().
 make_lkup_fun(AssignedName, Type) ->
-  Store0 = avro_schema_store:new([dict]),
+  Store0 = avro_schema_store:new([map]),
   Store = avro_schema_store:add_type(AssignedName, Type, Store0),
   avro_schema_store:to_lookup_fun(Store).
 

--- a/test/avro_schema_store_tests.erl
+++ b/test/avro_schema_store_tests.erl
@@ -35,11 +35,13 @@ get_all_types_test() ->
       ok = avro_schema_store:close(Store)
     end,
   ok = TestFun(avro_schema_store:new([{name, ?MODULE}])),
-  ok = TestFun(avro_schema_store:new([dict])).
+  ok = TestFun(avro_schema_store:new([dict])),
+  ok = TestFun(avro_schema_store:new([map])).
 
 is_store_test() ->
   ?assertNot(avro_schema_store:is_store(<<"json">>)),
   ?assert(avro_schema_store:is_store(avro_schema_store:new([dict]))),
+  ?assert(avro_schema_store:is_store(avro_schema_store:new([map]))),
   ?assert(avro_schema_store:is_store(avro_schema_store:new([]))).
 
 ensure_store_test() ->
@@ -52,7 +54,8 @@ ensure_store_test() ->
   ?assertEqual(1, avro_schema_store:ensure_store(1)),
   ?assertEqual(atom, avro_schema_store:ensure_store(atom)),
   ?assertEqual({dict, dict:new()},
-               avro_schema_store:ensure_store({dict, dict:new()})).
+               avro_schema_store:ensure_store({dict, dict:new()})),
+  ?assertEqual(#{}, avro_schema_store:ensure_store(#{})).
 
 flatten_type_test() ->
   Type = avro_array:type(test_record()),
@@ -81,7 +84,8 @@ add_type_test() ->
         ok = avro_schema_store:close(Store1)
     end,
   ok = TestFun(avro_schema_store:new()),
-  ok = TestFun(avro_schema_store:new([dict])).
+  ok = TestFun(avro_schema_store:new([dict])),
+  ok = TestFun(avro_schema_store:new([map])).
 
 lookup(Name, Store) ->
   avro_schema_store:lookup_type(Name, Store).

--- a/test/avro_tests.erl
+++ b/test/avro_tests.erl
@@ -337,7 +337,7 @@ wrapped_union_cast_test() ->
   Rec1 = avro_record:type("rec1", [avro_record:define_field("f1", int)]),
   Rec2 = avro_record:type("rec2", [avro_record:define_field("f1", int)]),
   Union = avro_union:type(["rec1", "rec2"]),
-  Store0 = avro_schema_store:new([dict]),
+  Store0 = avro_schema_store:new([map]),
   Store1 = avro_schema_store:add_type(Rec1, Store0),
   Store = avro_schema_store:add_type(Rec2, Store1),
   Lkup = avro_util:ensure_lkup_fun(Store),


### PR DESCRIPTION
- Add map as avro store, and use it as default.
- Changed to store type aliases as type's full name index, so the type store map (or dict) is less bloated.