### PR TITLE
chore: bump `snappyer` to OTP-27-ready 1.2.10

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -9,8 +9,8 @@
                        ]}.
 {edoc_opts,           [{preprocess, true}]}.
 {deps,
- [ {jsone, "1.8.1"},
-   {snappyer, "1.2.9"}
+ [ {jsone, "1.9.0"},
+   {snappyer, "1.2.10"}
  ]}.
 
 {cover_opts, [verbose]}.


### PR DESCRIPTION
Also bump `jsone` to the most recent release.