### PR TITLE
feat: support custom record field attributes

### DIFF
--- a/include/avro_internal.hrl
+++ b/include/avro_internal.hrl
@@ -35,12 +35,13 @@
 -define(NO_VALUE, undefined).
 
 -record(avro_record_field,
-        { name      = ?AVRO_REQUIRED :: name()
-        , doc       = ?NS_GLOBAL     :: typedoc()
-        , type      = ?AVRO_REQUIRED :: type_or_name()
-        , default                    :: ?NO_VALUE | avro:in() | avro_value()
-        , order     = ascending      :: ordering()
-        , aliases   = []             :: [name()]
+        { name              = ?AVRO_REQUIRED :: name()
+        , doc               = ?NS_GLOBAL     :: typedoc()
+        , type              = ?AVRO_REQUIRED :: type_or_name()
+        , default                            :: ?NO_VALUE | avro:in() | avro_value()
+        , order             = ascending      :: ordering()
+        , aliases           = []             :: [name()]
+        , custom_attributes = #{}            :: #{binary() => binary()}
         }).
 
 -type record_field() :: #avro_record_field{}.

--- a/src/avro_json_decoder.erl
+++ b/src/avro_json_decoder.erl
@@ -204,20 +204,29 @@ parse_record_fields(Fields) ->
 -spec parse_record_field([{binary(), json_value()}]) ->
         record_field() | no_return().
 parse_record_field(Attrs) ->
-  Name      = avro_util:get_opt(<<"name">>,    Attrs),
-  Doc       = avro_util:get_opt(<<"doc">>,     Attrs, <<"">>),
-  Type      = avro_util:get_opt(<<"type">>,    Attrs),
-  Default   = avro_util:get_opt(<<"default">>, Attrs, undefined),
-  Order     = avro_util:get_opt(<<"order">>,   Attrs, <<"ascending">>),
-  Aliases   = avro_util:get_opt(<<"aliases">>, Attrs, []),
-  FieldType = parse_schema(Type),
+  Name        = avro_util:get_opt(<<"name">>,    Attrs),
+  Doc         = avro_util:get_opt(<<"doc">>,     Attrs, <<"">>),
+  Type        = avro_util:get_opt(<<"type">>,    Attrs),
+  Default     = avro_util:get_opt(<<"default">>, Attrs, undefined),
+  Order       = avro_util:get_opt(<<"order">>,   Attrs, <<"ascending">>),
+  Aliases     = avro_util:get_opt(<<"aliases">>, Attrs, []),
+  Keys        = [ <<"name">>
+                , <<"doc">>
+                , <<"type">>
+                , <<"default">>
+                , <<"order">>
+                , <<"aliases">>
+                ],
+  CustomAttrs = avro_util:delete_opts(Attrs, Keys),
+  FieldType   = parse_schema(Type),
   #avro_record_field
-  { name    = ?NAME(Name)
-  , doc     = Doc
-  , type    = FieldType
-  , default = Default
-  , order   = parse_order(Order)
-  , aliases = parse_aliases(Aliases)
+  { name              = ?NAME(Name)
+  , doc               = Doc
+  , type              = FieldType
+  , default           = Default
+  , order             = parse_order(Order)
+  , aliases           = parse_aliases(Aliases)
+  , custom_attributes = maps:from_list(CustomAttrs)
   }.
 
 -spec parse_order(binary()) -> ascending | descending | ignore.

--- a/src/avro_json_encoder.erl
+++ b/src/avro_json_encoder.erl
@@ -299,9 +299,11 @@ encode_field(Field, EnclosingNamespace, Opt) ->
                     , type    = Type
                     , default = Default
                     , order   = Order
-                    , aliases = Aliases} = Field,
+                    , aliases = Aliases
+                    , custom_attributes = CustomAttributes} = Field,
   [ {name, encode_string(Name)}
   , {type, do_encode_type(Type, EnclosingNamespace, Opt)}
+  | maps:to_list(CustomAttributes)
   ]
   ++ optional_field(default, Default, ?NO_VALUE, fun(X) -> ?INLINE(X) end)
   ++ optional_field(doc,     Doc,     ?NO_DOC,   fun encode_string/1)

--- a/test/data/iceberg-manifest-file.avsc
+++ b/test/data/iceberg-manifest-file.avsc
@@ -1,0 +1,131 @@
+{
+  "type": "record",
+  "name": "manifest_file",
+  "fields": [
+    {
+      "name": "manifest_path",
+      "type": "string",
+      "doc": "Location URI with FS scheme",
+      "field-id": 500
+    },
+    {
+      "name": "manifest_length",
+      "type": "long",
+      "field-id": 501
+    },
+    {
+      "name": "partition_spec_id",
+      "type": "int",
+      "field-id": 502
+    },
+    {
+      "name": "content",
+      "type": "int",
+      "field-id": 517
+    },
+    {
+      "name": "sequence_number",
+      "type": "long",
+      "field-id": 515
+    },
+    {
+      "name": "min_sequence_number",
+      "type": "long",
+      "field-id": 516
+    },
+    {
+      "name": "added_snapshot_id",
+      "type": "long",
+      "field-id": 503
+    },
+    {
+      "name": "added_files_count",
+      "type": "int",
+      "field-id": 504
+    },
+    {
+      "name": "existing_files_count",
+      "type": "int",
+      "field-id": 505
+    },
+    {
+      "name": "deleted_files_count",
+      "type": "int",
+      "field-id": 506
+    },
+    {
+      "name": "added_rows_count",
+      "type": "long",
+      "field-id": 512
+    },
+    {
+      "name": "existing_rows_count",
+      "type": "long",
+      "field-id": 513
+    },
+    {
+      "name": "deleted_rows_count",
+      "type": "long",
+      "field-id": 514
+    },
+    {
+      "name": "partitions",
+      "type": [
+        "null",
+        {
+          "type": "array",
+          "items": {
+            "type": "record",
+            "name": "r508",
+            "fields": [
+              {
+                "name": "contains_null",
+                "type": "boolean",
+                "field-id": 509
+              },
+              {
+                "name": "contains_nan",
+                "type": [
+                  "null",
+                  "boolean"
+                ],
+                "default": null,
+                "field-id": 518
+              },
+              {
+                "name": "lower_bound",
+                "type": [
+                  "null",
+                  "bytes"
+                ],
+                "default": null,
+                "field-id": 510
+              },
+              {
+                "name": "upper_bound",
+                "type": [
+                  "null",
+                  "bytes"
+                ],
+                "default": null,
+                "field-id": 511
+              }
+            ]
+          },
+          "element-id": 508
+        }
+      ],
+      "default": null,
+      "field-id": 507
+    },
+    {
+      "name": "key_metadata",
+      "type": [
+        "null",
+        "bytes"
+      ],
+      "default": null,
+      "field-id": 519
+    }
+  ]
+}


### PR DESCRIPTION
Part of https://emqx.atlassian.net/browse/EMQX-14051

From the [Avro spec](https://avro.apache.org/docs/1.11.1/specification/#schema-declaration):

> Attributes not defined in this document are permitted as metadata, but must not affect
the format of serialized data.

Some applications, such as Apache Iceberg, when reading Avro-encoded files, expect some custom attributes to be present in the OCF file metadata.